### PR TITLE
Feature/vendor graph

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ cypress/reports
 
 # Docker artifacts
 Dockerfile
+Dockerfile.dev
 docker-compose.yml
 .dockerignore
 

--- a/CoVAR-app/package-lock.json
+++ b/CoVAR-app/package-lock.json
@@ -16,6 +16,7 @@
                 "@mui/x-data-grid": "^7.12.0",
                 "axios": "^1.7.0",
                 "axios-mock-adapter": "^1.22.0",
+                "echarts": "^5.5.1",
                 "firebase": "^10.12.2",
                 "next": "14.2.4",
                 "react": "^18",
@@ -6599,6 +6600,20 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
             }
+        },
+        "node_modules/echarts": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+            "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
+            "dependencies": {
+                "tslib": "2.3.0",
+                "zrender": "5.6.0"
+            }
+        },
+        "node_modules/echarts/node_modules/tslib": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.816",
@@ -13451,6 +13466,19 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zrender": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+            "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+            "dependencies": {
+                "tslib": "2.3.0"
+            }
+        },
+        "node_modules/zrender/node_modules/tslib": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
     }
 }

--- a/CoVAR-app/package.json
+++ b/CoVAR-app/package.json
@@ -18,6 +18,7 @@
         "@mui/x-data-grid": "^7.12.0",
         "axios": "^1.7.0",
         "axios-mock-adapter": "^1.22.0",
+        "echarts": "^5.5.1",
         "firebase": "^10.12.2",
         "next": "14.2.4",
         "react": "^18",

--- a/CoVAR-app/src/app/(pages)/vendorGraph/dataFormatConverter.tsx
+++ b/CoVAR-app/src/app/(pages)/vendorGraph/dataFormatConverter.tsx
@@ -1,0 +1,92 @@
+type TreeNode = {
+    name: string;
+    children?: TreeNode[];
+    symbolSize?: number;
+    itemStyle?: { color: string };
+};
+
+function calculateNodeColorAndSize(count: number, scale: number): { color: string; size: number } {
+    // Scale node size (you can adjust the multiplier as needed)
+    const size = Math.min(15 + count * 5, 50);
+
+    // Calculate the midpoint of the scale
+    const midpoint = scale / 2;
+
+    let red, green;
+
+    if (count <= midpoint) {
+        // Transition from green to yellow
+        red = Math.floor((count / midpoint) * 255);
+        green = 255;
+    } else {
+        // Transition from yellow to red
+        red = 255;
+        green = Math.floor((1 - ((count - midpoint) / midpoint)) * 255);
+    }
+
+    const color = `rgb(${red}, ${green}, 0)`;
+
+    return { color, size };
+}
+
+function convertHashToTreeData(inputHash: any): TreeNode[] {
+    const result: TreeNode[] = [];
+
+    for (const [software, versions] of Object.entries(inputHash)) {
+        const softwareNode: TreeNode = {
+            name: software,
+            children: []
+        };
+
+        for (const [version, cves] of Object.entries(versions as object)) {
+            const cveEntries = Object.entries(cves as object);
+            const versionNode: TreeNode = {
+                name: version,
+                children: []
+            };
+
+            cveEntries.forEach(([cve, count]) => {
+                const { color, size } = calculateNodeColorAndSize(count as number, 7);
+                const cveNode: TreeNode = {
+                name: `${cve}\nCount: ${count}`,
+                symbolSize: size,
+                itemStyle: { color }
+                };
+                versionNode.children!.push(cveNode);
+            });
+
+            // Calculate size and color for the version node based on the number of children
+            const { color: versionColor, size: versionSize } = calculateNodeColorAndSize(versionNode.children!.length, 40);
+            versionNode.symbolSize = versionSize;
+            versionNode.itemStyle = { color: versionColor };
+
+            softwareNode.children!.push(versionNode);
+        }
+
+        // Calculate size and color for the software node based on the number of children
+        const leafCount = softwareNode.children!.reduce((acc, versionNode) => {
+            return acc + versionNode.children!.length;
+        }, 0);
+          
+        const { color: softwareColor, size: softwareSize } = calculateNodeColorAndSize(leafCount, 35);
+
+        softwareNode.symbolSize = softwareSize;
+        softwareNode.itemStyle = { color: softwareColor };
+
+        result.push(softwareNode);
+    }
+
+    // Wrap the whole structure under a root node called "Vendor Issues" with a green color
+    const rootNode: TreeNode = {
+        name: "Vendor Issues",
+        itemStyle: { color: 'green' },
+        symbolSize: 50,
+        children: result
+    };
+
+    const modifiedResult: TreeNode[] = [];
+
+    return modifiedResult.concat(rootNode);
+}
+  
+export default convertHashToTreeData;

--- a/CoVAR-app/src/app/(pages)/vendorGraph/dataFormatConverter.tsx
+++ b/CoVAR-app/src/app/(pages)/vendorGraph/dataFormatConverter.tsx
@@ -1,15 +1,25 @@
 type TreeNode = {
     name: string;
     children?: TreeNode[];
-    symbolSize?: number;
-    itemStyle?: { color: string };
+    symbolSize?: number[];
+    itemStyle?: { color: string, borderRadius?: number };
+    symbol?: string;
+    label?: {
+        show?: boolean,
+        position: string, 
+        verticalAlign: string,
+        align: string,
+        fontSize: number,
+    };
+    tooltip?: {
+        show: boolean,
+        formatter: string,
+    };
 };
 
 function calculateNodeColorAndSize(count: number, scale: number): { color: string; size: number } {
-    // Scale node size (you can adjust the multiplier as needed)
-    const size = Math.min(15 + count * 5, 50);
+    const size = Math.min(15 + count * 5, 40);
 
-    // Calculate the midpoint of the scale
     const midpoint = scale / 2;
 
     let red, green;
@@ -35,30 +45,61 @@ function convertHashToTreeData(inputHash: any): TreeNode[] {
     for (const [software, versions] of Object.entries(inputHash)) {
         const softwareNode: TreeNode = {
             name: software,
-            children: []
+            children: [],
+            symbol: 'rect',
+            label: {
+                show: true,
+                position: 'inside', 
+                verticalAlign: 'middle',
+                align: 'center',
+                fontSize: 12,
+            }
         };
 
         for (const [version, cves] of Object.entries(versions as object)) {
             const cveEntries = Object.entries(cves as object);
             const versionNode: TreeNode = {
                 name: version,
-                children: []
+                children: [],
+                symbol: 'rect',
+                label: {
+                    show: true,
+                    position: 'inside', 
+                    verticalAlign: 'middle',
+                    align: 'center',
+                    fontSize: 12,
+                },
+                tooltip: {
+                    show: true,
+                    formatter: `Click to expand/retract CVE's related to ${software}:${version}`
+                }
             };
 
             cveEntries.forEach(([cve, count]) => {
                 const { color, size } = calculateNodeColorAndSize(count as number, 7);
                 const cveNode: TreeNode = {
-                name: `${cve}\nCount: ${count}`,
-                symbolSize: size,
-                itemStyle: { color }
+                    name: `${cve}\nCount: ${count}`,
+                    symbolSize: [size, size],
+                    itemStyle: { color },
+                    label: {
+                        show: true,
+                        position: 'inside', 
+                        verticalAlign: 'middle',
+                        align: 'center',
+                        fontSize: 8,
+                    },
+                    tooltip: {
+                        show: true,
+                        formatter: `Click to view information about ${cve}`
+                    }
                 };
                 versionNode.children!.push(cveNode);
             });
 
             // Calculate size and color for the version node based on the number of children
             const { color: versionColor, size: versionSize } = calculateNodeColorAndSize(versionNode.children!.length, 40);
-            versionNode.symbolSize = versionSize;
-            versionNode.itemStyle = { color: versionColor };
+            versionNode.symbolSize = [(versionNode.name.length * 8) + versionSize/4, versionSize];
+            versionNode.itemStyle = { color: versionColor, borderRadius: 15 };
 
             softwareNode.children!.push(versionNode);
         }
@@ -70,8 +111,8 @@ function convertHashToTreeData(inputHash: any): TreeNode[] {
           
         const { color: softwareColor, size: softwareSize } = calculateNodeColorAndSize(leafCount, 35);
 
-        softwareNode.symbolSize = softwareSize;
-        softwareNode.itemStyle = { color: softwareColor };
+        softwareNode.symbolSize = [(softwareNode.name.length * 8) + softwareSize/4, softwareSize];
+        softwareNode.itemStyle = { color: softwareColor, borderRadius: 20 };
 
         result.push(softwareNode);
     }
@@ -80,8 +121,15 @@ function convertHashToTreeData(inputHash: any): TreeNode[] {
     const rootNode: TreeNode = {
         name: "Vendor Issues",
         itemStyle: { color: 'green' },
-        symbolSize: 50,
-        children: result
+        symbolSize: [90, 40],
+        children: result,
+        label: {
+            show: true,
+            position: 'inside', 
+            verticalAlign: 'middle',
+            align: 'center',
+            fontSize: 12,
+        }
     };
 
     const modifiedResult: TreeNode[] = [];

--- a/CoVAR-app/src/app/(pages)/vendorGraph/page.tsx
+++ b/CoVAR-app/src/app/(pages)/vendorGraph/page.tsx
@@ -111,45 +111,41 @@ const VendorGraph: React.FC = () => {
 			return;
 		}
 		
-		let firstReport = '';
 		const reportMap: any = {};
 
 		reports.forEach((report, index) => {
 			const createDate = report.created_at;
 
 			if (index === 0) {
-				firstReport = createDate;
+				createVendorFixes(report);
+				setSelectedReport(createDate);
 			}
 
 			reportMap[createDate] = index;
 		});
 
 		setReportMap(reportMap);
-
-		// if (reportMap[firstReport] !== undefined) {
-		// changeReport(firstReport);
-		// }
-
 	}, [reports]);
 
 	return (
 		<Box sx={mainContentStyles}>
-			<FormControl fullWidth>
-				<InputLabel id="report-select-label">Select Report</InputLabel>
-				<Select
-				labelId="report-select-label"
-				value={selectedReport}
-				label="Select Report"
-				onChange={(e) => changeReport(e.target.value as string)}
-				>
-				{reportMap && Object.keys(reportMap).map((reportDate) => (
-					<MenuItem key={new Date(reportDate).toLocaleString()} value={reportDate}>
-						{new Date(reportDate).toLocaleString()}
-					</MenuItem>
-				))}
-				</Select>
-			</FormControl>
 			<Paper sx={chartContainerStyles}>
+				<FormControl fullWidth>
+					<InputLabel id="report-select-label">Select Report</InputLabel>
+					<Select
+					labelId="report-select-label"
+					value={selectedReport}
+					label="Select Report"
+					onChange={(e) => changeReport(e.target.value as string)}
+					>
+					{reportMap && Object.keys(reportMap).map((reportDate) => (
+						<MenuItem key={new Date(reportDate).toLocaleString()} value={reportDate}>
+							{new Date(reportDate).toLocaleString()}
+						</MenuItem>
+					))}
+					</Select>
+				</FormControl>
+
 				<VendorGraphTree data={vendorFixes}/>
 			</Paper>
 		</Box>

--- a/CoVAR-app/src/app/(pages)/vendorGraph/page.tsx
+++ b/CoVAR-app/src/app/(pages)/vendorGraph/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Typography, Paper, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { mainContentStyles } from '../../../styles/sidebarStyle';
+import { getAllReports } from '@/functions/requests';
+import { VulnerabilityReport } from '../dashboard/page';
+import { chartContainerStyles } from '@/styles/dashboardStyle';
+
+type versionCount = {
+	[version: string]: number,
+}
+
+type vendorFixes = {
+	[vendor: string]: versionCount,
+}
+
+const VendorGraph: React.FC = () => {
+	const [vendorFixes, setVendorFixes] = useState<vendorFixes>();
+	const [reports, setReports] = useState<any[]>([]);
+	const [reportMap, setReportMap] = useState<any>({});
+	const [selectedReport, setSelectedReport] = useState('');
+    const initialMount = useRef(true);
+
+	const createVendorFixes = (report:any) => {
+		const vendors: vendorFixes = {};
+		const vulnerabilities: VulnerabilityReport[] = report.content.finalReport;
+
+		for (const vulnerability of vulnerabilities) {
+			if(vulnerability.solutionType != "VendorFix"){
+				continue;
+			}
+
+			let vendor = vulnerability.nvtName.split(" ")[0];
+			vendor = vendor.replace(/:$/, "");
+
+			if (!vendors[vendor]) {
+				vendors[vendor] = {};
+			}
+
+			const installedVersionMatch = vulnerability.specificResult.match(/Installed version:\s*([\d.]+)/);
+			if (installedVersionMatch) {
+				const installedVersion = installedVersionMatch[1];
+
+				if (!vendors[vendor][installedVersion]) {
+					vendors[vendor][installedVersion] = 1;
+				} else {
+					vendors[vendor][installedVersion]++;
+				}
+			}
+		}
+
+		setVendorFixes(vendors);
+	}
+
+	const changeReport = (reportDate: string) => {
+		if (reportMap[reportDate] === undefined) {
+			return;
+		}
+
+		const report = reports[reportMap[reportDate]];
+		createVendorFixes(report);
+		setSelectedReport(reportDate);
+	}
+
+	const fetchReports = async () => {
+		try {
+			const responseData = await getAllReports();
+			setReports(responseData);
+		} catch (error) {
+			console.log(error);
+		}
+	};
+
+	useEffect(() => {
+		if (initialMount.current) {
+            fetchReports();
+            initialMount.current = false;
+        }
+	}, []);
+
+	useEffect(() => {
+		if(reports?.length == undefined || reports.length < 1){
+			return;
+		}
+		
+		let firstReport = '';
+		const reportMap: any = {};
+
+		reports.forEach((report, index) => {
+			const createDate = report.created_at;
+
+			if (index === 0) {
+				firstReport = createDate;
+			}
+
+			reportMap[createDate] = index;
+		});
+
+		setReportMap(reportMap);
+
+		// if (reportMap[firstReport] !== undefined) {
+		// changeReport(firstReport);
+		// }
+
+	}, [reports]);
+
+	return (
+		<Box sx={mainContentStyles}>
+			<FormControl fullWidth>
+				<InputLabel id="report-select-label">Select Report</InputLabel>
+				<Select
+				labelId="report-select-label"
+				value={selectedReport}
+				label="Select Report"
+				onChange={(e) => changeReport(e.target.value as string)}
+				>
+				{reportMap && Object.keys(reportMap).map((reportDate) => (
+					<MenuItem key={new Date(reportDate).toLocaleString()} value={reportDate}>
+						{new Date(reportDate).toLocaleString()}
+					</MenuItem>
+				))}
+				</Select>
+			</FormControl>
+			<Paper sx={chartContainerStyles}>
+				<Typography variant="h6">{JSON.stringify(vendorFixes, null, 2)}</Typography>
+			</Paper>
+		</Box>
+	);
+};
+
+export default VendorGraph;

--- a/CoVAR-app/src/app/(pages)/vendorGraph/vendorGraphTree.tsx
+++ b/CoVAR-app/src/app/(pages)/vendorGraph/vendorGraphTree.tsx
@@ -1,0 +1,70 @@
+'use client';
+import React, { useEffect, useRef } from 'react';
+import * as echarts from 'echarts';
+
+interface VendorGraphTreeProps {
+  data: any[];
+}
+
+const VendorGraphTree: React.FC<VendorGraphTreeProps> = ({ data }) => {
+  const chartRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let chartInstance: echarts.ECharts | null = null;
+    if (chartRef.current) {
+      chartInstance = echarts.init(chartRef.current);
+
+      const option = {
+        series: [
+          {
+            type: 'tree',
+            data: data,
+            top: '5%',
+            left: '7%',
+            bottom: '5%',
+            right: '15%',
+            symbol: 'circle',
+            symbolSize: 30,
+            layout: 'orthogonal',
+            orient: 'TB',
+            label: {
+              position: 'top',
+              verticalAlign: 'middle',
+              align: 'center',
+              fontSize: 12,
+            },
+            leaves: {
+              label: {
+                position: 'top',
+                verticalAlign: 'middle',
+                align: 'center',
+              },
+            },
+            expandAndCollapse: true,
+            initialTreeDepth: 2,
+            animationDurationUpdate: 750,
+          },
+        ],
+        tooltip: {
+          trigger: 'item',
+          triggerOn: 'mousemove',
+        },
+      };
+
+      chartInstance.setOption(option);
+    }
+
+    return () => {
+      chartInstance?.dispose();
+    };
+  }, [data]);
+
+  return (
+    <div
+      ref={chartRef}
+      style={{ width: '100%', height: '100%', border: '1px solid gray' }}
+    ></div>
+  );
+};
+
+export default VendorGraphTree;

--- a/CoVAR-app/src/app/(pages)/vendorGraph/vendorGraphTree.tsx
+++ b/CoVAR-app/src/app/(pages)/vendorGraph/vendorGraphTree.tsx
@@ -20,29 +20,20 @@ const VendorGraphTree: React.FC<VendorGraphTreeProps> = ({ data }) => {
             type: 'tree',
             data: data,
             top: '5%',
-            left: '7%',
+            left: '1%',
             bottom: '5%',
-            right: '15%',
+            right: '1%',
             symbol: 'circle',
             symbolSize: 30,
             layout: 'orthogonal',
             orient: 'TB',
-            label: {
-              position: 'top',
-              verticalAlign: 'middle',
-              align: 'center',
-              fontSize: 12,
-            },
-            leaves: {
-              label: {
-                position: 'top',
-                verticalAlign: 'middle',
-                align: 'center',
-              },
-            },
             expandAndCollapse: true,
             initialTreeDepth: 2,
             animationDurationUpdate: 750,
+            lineStyle: {
+              width: 1.5,
+              curveness: 0,
+            },
           },
         ],
         tooltip: {
@@ -52,6 +43,15 @@ const VendorGraphTree: React.FC<VendorGraphTreeProps> = ({ data }) => {
       };
 
       chartInstance.setOption(option);
+
+      chartInstance.on('click', function (params) {
+        const nodeData = params?.data as { children?: any[]; name: string };
+        if (!nodeData?.children) {
+          const cveName = nodeData.name.split('\n')[0];
+          const url = `https://www.cvedetails.com/cve/${cveName}/`;
+          window.open(url, '_blank');
+        }
+      });
     }
 
     return () => {

--- a/CoVAR-app/src/app/sidebar.tsx
+++ b/CoVAR-app/src/app/sidebar.tsx
@@ -105,7 +105,7 @@ const Sidebar: React.FC = () => {
   return (
     <Box sx={sidebarStyles}>
       <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', ...logoStyles }}>
-        <LockIcon sx={{ fontSize: '14', marginRight: 1, color: theme.palette.primary.main }} /> CoVAR
+        <LockIcon sx={{ fontSize: '20', marginRight: 1, color: theme.palette.primary.main }} /> CoVAR
       </Typography>
       <List>
         <Link href='/dashboard'>

--- a/CoVAR-app/src/app/sidebar.tsx
+++ b/CoVAR-app/src/app/sidebar.tsx
@@ -9,6 +9,7 @@ import LockIcon from '@mui/icons-material/Lock';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { Box, Button, List, ListItem, ListItemIcon, ListItemText, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
+import BubbleChartIcon from '@mui/icons-material/BubbleChart';
 
 import { useThemeContext } from '../styles/customThemeProvider';
 import { iconStyles, logoStyles, logoutButtonStyles, sidebarItemStyles, sidebarStyles } from '../styles/sidebarStyle';
@@ -126,6 +127,28 @@ const Sidebar: React.FC = () => {
             <ListItemText primary="Dashboard" />
           </ListItem>
         </Link>
+        {role === "client" && (
+          <Link href='/vendorGraph'>
+            <ListItem
+              test-id="vendorGraphLink"
+              sx={{
+                ...sidebarItemStyles,
+                backgroundColor: isActive('/vendorGraph') ? theme.palette.primary.main : 'inherit',
+                color: isActive('/vendorGraph') ? 'white' : theme.palette.text.primary,
+                borderRadius: '10px',
+                '&:hover': {
+                  backgroundColor: theme.palette.action.hover,
+                  color: theme.palette.text.primary,
+                },
+              }}
+            >
+              <ListItemIcon sx={{ ...iconStyles, color: isActive('/vendorGraph') ? 'white' : theme.palette.text.primary }}>
+                <BubbleChartIcon />
+              </ListItemIcon>
+              <ListItemText primary="Vendor Graph" />
+            </ListItem>
+          </Link>
+        )}
         {(role === "va" || role === "admin") && (
           <Link href='/evaluate'>
             <ListItem

--- a/CoVAR-app/src/styles/themes.tsx
+++ b/CoVAR-app/src/styles/themes.tsx
@@ -82,7 +82,7 @@ const darkTheme = createTheme({
       paper: '#2D3E44',
     },
     text: {
-      primary: '#CAD2C5',
+      primary: '#EDEDED',
       secondary: '#84A98C',
     },
     action: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     depends_on:
       - api
       - client
-    restart: always
     build:
       dockerfile: Dockerfile.dev
       context: './nginx'


### PR DESCRIPTION
## Description
Added a new tab for vendor graph.
You can interact with the nodes of the graph to expand or retract child nodes. 
Each node's color and size depends on the amount of children/problems related to it.
For leaf nodes you can click on the node and it takes you to a website describing the CVE.

## Changes Made
Also changed dark mode text color to be brighter.
Increased the font size of the CoVAR in the sidebar.
Fixed the nginx restart bug.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d6a77c30-35bb-43c6-a4ca-c395441cceaa)